### PR TITLE
Extend distinct-deployments.json with additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ The default name for the deployed application is ``ctfd``. If you want to overri
 oc new-app https://raw.githubusercontent.com/openshift-evangelists/ctfd-quickstart/master/templates/all-in-one-deployment.json --param APPLICATION_NAME=ctfd
 ```
 
-The Git repository URL and Git reference can be overridden using the ``GIT_REPOSITORY_URL`` and ``GIT_REFERENCE`` template parameters.
+The Git repository URL and Git reference can be overridden using the ``GIT_REPOSITORY_URL`` and ``GIT_REFERENCE`` template parameters. Other parameters can also be customized by passing either ``--param`` or ``--param-file`` to ``oc new-app``. Example:
+
+```
+echo -e "MYSQL_VOLUME_SIZE=2Gi\nPYTHON_VERSION=2.7" > params
+oc new-app --file=distinct-deployments.json --param-file=params
+```
 
 Scaling up the application
 --------------------------

--- a/templates/all-in-one-deployment.json
+++ b/templates/all-in-one-deployment.json
@@ -21,6 +21,16 @@
             "required": true
         },
         {
+            "name": "MOD_WSGI_PROCESSES",
+            "value": "1",
+            "required": true
+        },
+        {
+            "name": "MOD_WSGI_THREADS",
+            "value": "5",
+            "required": true
+        },
+        {
             "name": "REDIS_PASSWORD",
             "from": "[a-zA-Z0-9]{16}",
             "generate": "expression",
@@ -59,6 +69,31 @@
             "name": "DATA_VOLUME_SIZE",
             "value": "1Gi",
             "required": true
+        },
+        {
+            "name": "BUILD_POD_MEMORY_LIMIT",
+            "value": "1Gi",
+            "required": true
+        },
+        {
+            "name": "CTFD_MEMORY_LIMIT",
+            "value": "256Mi",
+            "required": true
+        },
+        {
+            "name": "REDIS_MEMORY_LIMIT",
+            "value": "256Mi",
+            "required": true
+        },
+        {
+            "name": "MYSQL_MEMORY_LIMIT",
+            "value": "512Mi",
+            "required": true
+        },
+        {
+            "name": "PYTHON_VERSION",
+            "value": "3.6",
+            "required": true
         }
     ],
     "objects": [
@@ -87,6 +122,11 @@
                 }
             },
             "spec": {
+                "resources": {
+                    "limits": {
+                        "memory": "${BUILD_POD_MEMORY_LIMIT}"
+                    }
+                },
                 "triggers": [
                     {
                         "type": "ConfigChange"
@@ -108,7 +148,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "openshift",
-                            "name": "python:3.6"
+                            "name": "python:${PYTHON_VERSION}"
                         },
                         "scripts": "https://raw.githubusercontent.com/openshift-evangelists/ctfd-quickstart/master/s2i/bin"
                     }
@@ -235,11 +275,11 @@
                                         "protocol": "TCP"
                                     }
                                 ],
-				"resources": {
-				    "limits": {
-					"memory": "256Mi"
-				    }
-				},
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${CTFD_MEMORY_LIMIT}"
+                                    }
+                                },
                                 "env": [
                                     {
                                         "name": "SECRET_KEY",
@@ -260,6 +300,14 @@
                                     {
                                         "name": "LOG_FOLDER",
                                         "value": "/var/logs/CTFd"
+                                    },
+                                    {
+                                        "name": "MOD_WSGI_PROCESSES",
+                                        "value": "${MOD_WSGI_PROCESSES}"
+                                    },
+                                    {
+                                        "name": "MOD_WSGI_THREADS",
+                                        "value": "${MOD_WSGI_THREADS}"
                                     }
                                 ],
                                 "volumeMounts": [
@@ -283,11 +331,11 @@
                                         "protocol": "TCP"
                                     }
                                 ],
-				"resources": {
-				    "limits": {
-					"memory": "256Mi"
-				    }
-				},
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${REDIS_MEMORY_LIMIT}"
+                                    }
+                                },
                                 "env": [
                                     {
                                         "name": "REDIS_PASSWORD",
@@ -310,11 +358,11 @@
                                         "protocol": "TCP"
                                     }
                                 ],
-				"resources": {
-				    "limits": {
-					"memory": "512Mi"
-				    }
-				},
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${MYSQL_MEMORY_LIMIT}"
+                                    }
+                                },
                                 "env": [
                                     {
                                         "name": "MYSQL_USER",

--- a/templates/distinct-deployments.json
+++ b/templates/distinct-deployments.json
@@ -21,6 +21,16 @@
             "required": true
         },
         {
+            "name": "MOD_WSGI_PROCESSES",
+            "value": "1",
+            "required": true
+        },
+        {
+            "name": "MOD_WSGI_THREADS",
+            "value": "5",
+            "required": true
+        },
+        {
             "name": "REDIS_PASSWORD",
             "from": "[a-zA-Z0-9]{16}",
             "generate": "expression",
@@ -69,6 +79,31 @@
             "name": "REDIS_VOLUME_SIZE",
             "value": "1Gi",
             "required": true
+        },
+        {
+            "name": "BUILD_POD_MEMORY_LIMIT",
+            "value": "1Gi",
+            "required": true
+        },
+        {
+            "name": "CTFD_MEMORY_LIMIT",
+            "value": "256Mi",
+            "required": true
+        },
+        {
+            "name": "REDIS_MEMORY_LIMIT",
+            "value": "256Mi",
+            "required": true
+        },
+        {
+            "name": "MYSQL_MEMORY_LIMIT",
+            "value": "512Mi",
+            "required": true
+        },
+        {
+            "name": "PYTHON_VERSION",
+            "value": "3.6",
+            "required": true
         }
     ],
     "objects": [
@@ -97,6 +132,11 @@
                 }
             },
             "spec": {
+                "resources": {
+                    "limits": {
+                        "memory": "${BUILD_POD_MEMORY_LIMIT}"
+                    }
+                },
                 "triggers": [
                     {
                         "type": "ConfigChange"
@@ -118,7 +158,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "openshift",
-                            "name": "python:3.6"
+                            "name": "python:${PYTHON_VERSION}"
                         },
                         "scripts": "https://raw.githubusercontent.com/openshift-evangelists/ctfd-quickstart/master/s2i/bin"
                     }
@@ -217,11 +257,11 @@
                                         "protocol": "TCP"
                                     }
                                 ],
-				"resources": {
-				    "limits": {
-					"memory": "256Mi"
-				    }
-				},
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${CTFD_MEMORY_LIMIT}"
+                                    }
+                                },
                                 "env": [
                                     {
                                         "name": "SECRET_KEY",
@@ -242,6 +282,14 @@
                                     {
                                         "name": "LOG_FOLDER",
                                         "value": "/var/logs/CTFd"
+                                    },
+                                    {
+                                        "name": "MOD_WSGI_PROCESSES",
+                                        "value": "${MOD_WSGI_PROCESSES}"
+                                    },
+                                    {
+                                        "name": "MOD_WSGI_THREADS",
+                                        "value": "${MOD_WSGI_THREADS}"
                                     }
                                 ],
                                 "volumeMounts": [
@@ -396,11 +444,11 @@
                                         "protocol": "TCP"
                                     }
                                 ],
-				"resources": {
-				    "limits": {
-					"memory": "256Mi"
-				    }
-				},
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${REDIS_MEMORY_LIMIT}"
+                                    }
+                                },
                                 "env": [
                                     {
                                         "name": "REDIS_PASSWORD",
@@ -528,11 +576,11 @@
                                         "protocol": "TCP"
                                     }
                                 ],
-				"resources": {
-				    "limits": {
-					"memory": "512Mi"
-				    }
-				},
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${MYSQL_MEMORY_LIMIT}"
+                                    }
+                                },
                                 "env": [
                                     {
                                         "name": "MYSQL_USER",


### PR DESCRIPTION
This PR makes it possible for user of `distinct_deployment.json` and `all-in-one-deployment.json` template to further customize their deployment by exposing few parameters that used to be hard-coded before.

